### PR TITLE
make it extensible and add support for C/C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ https://github.com/xlboy/swap-ternary.nvim/assets/63690944/2324c998-3e18-4989-90
 - `javascriptreact`
 - `typescript`
 - `typescriptreact`
+- `c`
+- `cpp`
 
 ## Install
 
@@ -20,4 +22,20 @@ https://github.com/xlboy/swap-ternary.nvim/assets/63690944/2324c998-3e18-4989-90
 
 ## How to use?
 
-Position the cursor over the ternary expression and then execute `require('swap-ternary').start()`
+Position the cursor over the ternary expression and then execute `:lua require('swap-ternary').start()` or `:call swap_ternary#swap()`.
+
+It's more convenient to define a keybinding with `<leader>`.
+
+In `.vimrc`:
+
+```vim
+nnoremap <leader>S :call swap_ternary#swap()<CR>
+" nnoremap <leader>S :lua require('swap-ternary').start()<CR>
+```
+
+In `init.lua`:
+
+```lua
+vim.api.nvim_set_keymap('n', '<leader>S', ':lua require("swap-ternary").start()<CR>', { noremap = true, silent = true })
+-- vim.api.nvim_set_keymap('n', '<leader>S', ':call swap_ternary#swap()<CR>', { noremap = true, silent = true })
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/xlboy/swap-ternary.nvim/assets/63690944/2324c998-3e18-4989-90
 
 ## How to use?
 
-Position the cursor over the ternary expression and then execute `:lua require('swap-ternary').start()` or `:call swap_ternary#swap()`.
+Position the cursor over the ternary expression and then execute `:lua require('swap-ternary').swap()` or `:call swap_ternary#swap()`.
 
 It's more convenient to define a keybinding with `<leader>`.
 
@@ -30,12 +30,12 @@ In `.vimrc`:
 
 ```vim
 nnoremap <leader>S :call swap_ternary#swap()<CR>
-" nnoremap <leader>S :lua require('swap-ternary').start()<CR>
+" nnoremap <leader>S :lua require('swap-ternary').swap()<CR>
 ```
 
 In `init.lua`:
 
 ```lua
-vim.api.nvim_set_keymap('n', '<leader>S', ':lua require("swap-ternary").start()<CR>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<leader>S', ':lua require("swap-ternary").swap()<CR>', { noremap = true, silent = true })
 -- vim.api.nvim_set_keymap('n', '<leader>S', ':call swap_ternary#swap()<CR>', { noremap = true, silent = true })
 ```

--- a/autoload/swap_ternary.vim
+++ b/autoload/swap_ternary.vim
@@ -1,0 +1,7 @@
+scriptencoding utf-8
+
+function! swap_ternary#swap() abort
+  if has('nvim')
+    lua require'swap-ternary'.start()
+  endif
+endfunction

--- a/autoload/swap_ternary.vim
+++ b/autoload/swap_ternary.vim
@@ -2,6 +2,6 @@ scriptencoding utf-8
 
 function! swap_ternary#swap() abort
   if has('nvim')
-    lua require'swap-ternary'.start()
+    lua require'swap-ternary'.swap()
   endif
 endfunction

--- a/lua/swap-ternary/controller.lua
+++ b/lua/swap-ternary/controller.lua
@@ -8,6 +8,9 @@ local file_type = {
   is_ts_or_js = function(type) --- @type FileTypeIsXXX
     return string.match(type, "typescript") or string.match(type, "javascript")
   end,
+  is_c_or_cpp = function (type)
+    return string.match(type, "cpp") or string.match(type,"c++") or string.match(type,"c")
+  end
 }
 
 ---@return NodeProcessor
@@ -16,6 +19,9 @@ local function get_node_processor(buf)
   if file_type.is_ts_or_js(_file_type) then
     return require("swap-ternary.node-processor.js-or-ts")
   end
+  if file_type.is_c_or_cpp(_file_type) then
+    return require("swap-ternary.node-processor.c-or-cpp")
+  end
 end
 
 function M.start()
@@ -23,7 +29,7 @@ function M.start()
 
   local node_tree = vim.treesitter.get_parser(current_buf)
   if not node_tree then
-    return vim.notify("[swap-ternary] Node tree is empty", vim.log.levels.ERROR)
+    return vim.notify("[swap-ternary] Node tree is empty or parser is missing for current buffer", vim.log.levels.ERROR)
   end
 
   local node_processor = get_node_processor(current_buf)

--- a/lua/swap-ternary/init.lua
+++ b/lua/swap-ternary/init.lua
@@ -13,7 +13,7 @@
 
 local M = {}
 
-function M.start()
+function M.swap()
   require("swap-ternary.controller").start()
 end
 

--- a/lua/swap-ternary/node-processor/c-or-cpp.lua
+++ b/lua/swap-ternary/node-processor/c-or-cpp.lua
@@ -6,7 +6,7 @@ local common = require("swap-ternary.node-processor.common")
 local M = {}
 
 function M.find_ternary_node_at_cursor(node_tree)
-  return common.find_node_at_cursor(node_tree, "ternary_expression")
+ return common.find_node_at_cursor(node_tree, "conditional_expression")
 end
 
 function M.get_target_nodes(node)

--- a/lua/swap-ternary/node-processor/common.lua
+++ b/lua/swap-ternary/node-processor/common.lua
@@ -1,0 +1,54 @@
+-- luacheck: globals vim
+
+local utils = require("swap-ternary.utils")
+--- @type NodeProcessor
+--- @diagnostic disable-next-line: missing-fields
+local M = {}
+
+function M.find_node_at_cursor(node_tree, node_type)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local cursor_line = cursor[1] - 1
+  local cursor_col = cursor[2] - 1
+
+  -- { start_line, start_col, end_line, end_col }
+  -- return: TSNode
+  local node = node_tree:named_node_for_range({ cursor_line, cursor_col, cursor_line, cursor_col + 1 })
+  while node do
+    if node:type() == node_type then
+      return node
+    end
+    node = node:parent()
+  end
+end
+
+function M.get_target_nodes(ternary_node)
+  local target_nodes = {
+    cond = nil,
+    cons = nil,
+    alt = nil,
+  }
+
+  for c_node, c_node_name in ternary_node:iter_children() do
+    if c_node_name == "condition" then
+      target_nodes.cond = c_node
+    end
+    if c_node_name == "consequence" then
+      target_nodes.cons = c_node
+    end
+    if c_node_name == "alternative" then
+      target_nodes.alt = c_node
+    end
+  end
+
+  return target_nodes
+end
+
+function M.recombination(target_nodes, buf)
+  local cond_texts = utils.get_buf_texts_by_node(buf, target_nodes.cond)
+  local cons_texts = utils.get_buf_texts_by_node(buf, target_nodes.cons)
+  local alt_texts = utils.get_buf_texts_by_node(buf, target_nodes.alt)
+
+  return utils.merge_texts({ cond_texts, { " ? " }, alt_texts, { " : " }, cons_texts })
+end
+
+return M

--- a/lua/swap-ternary/utils.lua
+++ b/lua/swap-ternary/utils.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals vim
 local M = {}
 
 ---@param buf integer

--- a/plugin/swap_ternary.lua
+++ b/plugin/swap_ternary.lua
@@ -1,7 +1,0 @@
--- luacheck: globals vim
-
-if vim.g.loaded_swap_ternary then
-  return
-end
-vim.g.loaded_swap_ternary = true
-

--- a/plugin/swap_ternary.lua
+++ b/plugin/swap_ternary.lua
@@ -1,0 +1,7 @@
+-- luacheck: globals vim
+
+if vim.g.loaded_swap_ternary then
+  return
+end
+vim.g.loaded_swap_ternary = true
+

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -38,6 +38,6 @@ end
 
 require("plenary.busted")
 require("nvim-treesitter.configs").setup({
-  ensure_installed = { "javascript", "javascriptreact", "typescript", "tsx" },
+  ensure_installed = { "javascript", "typescript", "tsx", "c", "cpp"},
   sync_install = true,
 })

--- a/tests/node-processors/c-or-cpp_spec.lua
+++ b/tests/node-processors/c-or-cpp_spec.lua
@@ -1,0 +1,97 @@
+local processor = require("swap-ternary.node-processor.c-or-cpp")
+local common = require("tests.node-processors.common")
+
+local function create_c_cpp_textures(ftype)
+  return {
+    {
+      file_type = ftype,
+      code = string.format(
+        [[
+true ? "1111" %s: "aaa" || "bbb";
+        ]],
+        common.constants.CURSOR_EMOJI
+      ),
+      ternary_node = {
+        range = { 0, 0, 0, 30 },
+        texts = { 'true ? "1111" : "aaa" || "bbb"' },
+      },
+      target_nodes = {
+        cond = {
+          texts = { "true" },
+          range = { 0, 0, 0, 4 },
+        },
+        cons = {
+          texts = { '"1111"' },
+          range = { 0, 7, 0, 13 },
+        },
+        alt = {
+          texts = { '"aaa" || "bbb"' },
+          range = { 0, 16, 0, 30 },
+        },
+      },
+      recomposed_texts = { 'true ? "aaa" || "bbb" : "1111"' },
+    },
+    {
+      file_type = ftype,
+      code = string.format(
+        [[
+true ? "3333" %s: (false ? "eee" : "fff") && "ggg";
+        ]],
+        common.constants.CURSOR_EMOJI
+      ),
+      ternary_node = {
+        texts = { 'true ? "3333" : (false ? "eee" : "fff") && "ggg"' },
+        range = { 0, 0, 0, 48 },
+      },
+      target_nodes = {
+        cond = {
+          texts = { "true" },
+          range = { 0, 0, 0, 4 },
+        },
+        cons = {
+          texts = { '"3333"' },
+          range = { 0, 7, 0, 13 },
+        },
+        alt = {
+          texts = { '(false ? "eee" : "fff") && "ggg"' },
+          range = { 0, 16, 0, 48 },
+        },
+      },
+      recomposed_texts = { 'true ? (false ? "eee" : "fff") && "ggg" : "3333"' },
+    },
+    {
+      file_type = ftype,
+      code = string.format(
+        [[
+true ? "3333" : (%sfalse ? "eee" : "fff") && "ggg";
+        ]],
+        common.constants.CURSOR_EMOJI
+      ),
+      ternary_node = {
+        texts = { 'false ? "eee" : "fff"' },
+        range = { 0, 17, 0, 38 },
+      },
+      target_nodes = {
+        cond = {
+          texts = { "false" },
+          range = { 0, 17, 0, 22 },
+        },
+        cons = {
+          texts = { '"eee"' },
+          range = { 0, 25, 0, 30 },
+        },
+        alt = {
+          texts = { '"fff"' },
+          range = { 0, 33, 0, 38 },
+        },
+      },
+      recomposed_texts = { 'false ? "fff" : "eee"' },
+    },
+  }
+end
+
+local c_test_sources = common.define_test_sources(create_c_cpp_textures("c"))
+local cpp_test_sources = common.define_test_sources(create_c_cpp_textures("cpp"))
+
+common.test_processor(processor, c_test_sources)
+common.test_processor(processor, cpp_test_sources)


### PR DESCRIPTION
Thanks for your work.

Here is what includes in this PR.

1.  Make it more extensible by reusing the shared logic for swapping nodes.

We can add more processors for languages that support the ternary expression. 

2. Add support for C and C++

I've also added tests by reusing some test cases from `js`. BTW, This can be further optimized since all languages with ternary expression look similar.

3. Remove `javascriptreact` in `tests/init.lua`.

I believe it has been included in the `tree-sitter-javascript` parser.

4. Add a VimScript function `swap_ternary#swap()`.

I think it's more easier to type than `require('swap-ternary').start()`. The `swap_ternary#swap()` is merely a wrapper of `require('swap-ternary').start()`.

5. Polish up README

Add instructions on how to setup a keybinding for this plugin.

6. Add `plugin/swap_ternary.lua`

The `plugin/swap_ternary.lua` is an indicator for me to test whether this plugin has been loaded. It's up to you to decide whether to add this file.